### PR TITLE
[slack] Update files metric

### DIFF
--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -139,16 +139,12 @@ class SlackEnrich(Enrich):
                 for i in range(0, rdata['count']):
                     eitem['reactions'].append(rdata["name"])
 
-        if 'file' in message:
-            eitem['file_type'] = message['file']['pretty_type']
-            eitem['file_title'] = message['file']['title']
-            eitem['file_size'] = message['file']['size']
-            eitem['file_name'] = message['file']['name']
-            eitem['file_mode'] = message['file']['mode']
-            eitem['file_is_public'] = message['file']['is_public']
-            eitem['file_is_external'] = message['file']['is_external']
-            eitem['file_id'] = message['file']['id']
-            eitem['file_is_editable'] = message['file']['editable']
+        if 'files' in message:
+            eitem['number_files'] = len(message['files'])
+            message_file_size = 0
+            for file in message['files']:
+                message_file_size += file.get('size', 0)
+            eitem['message_file_size'] = message_file_size
 
         if 'user_data' in message:
             eitem['team_id'] = message['user_data']['team_id']

--- a/schema/slack.csv
+++ b/schema/slack.csv
@@ -1,60 +1,63 @@
-name,type
-author_bot,long
-author_domain,keyword
-author_id,keyword
-author_name,keyword
-author_org_name,keyword
-author_user_name,keyword
-author_uuid,keyword
-avatar,keyword
-channel_created,long
-channel_id,keyword
-channel_is_archived,long
-channel_is_general,long
-channel_is_starred,long
-channel_member_count,long
-channel_name,keyword
-file_id,keyword
-file_is_editable,long
-file_is_external,long
-file_is_public,long
-file_mode,keyword
-file_name,keyword
-file_size,long
-file_title,keyword
-file_type,keyword
-grimoire_creation_date,date
-is_admin,long
-is_owner,long
-is_primary_owner,long
-is_slack_message,long
-metadata__enriched_on,date
-metadata__gelk_backend_name,keyword
-metadata__gelk_version,keyword
-metadata__timestamp,date
-metadata__updated_on,date
-number_attachs,long
-origin,keyword
-profile_title,keyword
-reaction_count,long
-reactions,keyword
-reply_count,long
-repository_labels,keyword
-subscribed,long
-subtype,keyword
-tag,keyword
-team_id,keyword
-text_analyzed,text
-text,keyword
-type,keyword
-tz,long
-unread_count,long
-user_data_bot,long
-user_data_domain,keyword
-user_data_id,keyword
-user_data_name,keyword
-user_data_org_name,keyword
-user_data_user_name,keyword
-user_data_uuid,keyword
-user,keyword
-uuid,keyword
+name,type,aggregatable,description
+author_bot,boolean,true,"True if the given author is identified as a bot."
+author_domain,keyword,true,"Domain associated to the author in SortingHat profile."
+author_gender,keyword,true,"Author gender."
+author_gender_acc,keyword,true,"Accuracy to assess author gender."
+author_id,keyword,true,"Author Id from SortingHat."
+author_multi_org_names,keyword,true,"List of the author organizations from SortingHat profile."
+author_name,keyword,true,"Author name."
+author_org_name,keyword,true,"Author organization name from SortingHat profile."
+author_user_name,keyword,true,"Author username from Sortinghat profile."
+author_uuid,keyword,true,"Author UUID from SortingHat."
+avatar,keyword,true,"Avatar associated with User profile."
+channel_created,date,true,"Date when channel was created in UNIX timestamp format."
+channel_id,keyword,long,true,"Channel Id of a Slack channel."
+channel_is_archived,long,true,"1 indicating that the channel is archived."
+channel_is_general,long,true,"1 indicating that the channel is general."
+channel_is_starred,long,true,"1 indicating that the channel is starred."
+channel_member_count,long,true,"Number of members in a Slack channel."
+channel_name,keyword,true,"Channel Name."
+channel_purpose,keyword,true,"Channel purpose."
+channel_topic,keyword,true,"Channel topic."
+grimoire_creation_date,date,true,"Message creation date."
+is_admin,long,true,"1 indicating the user is an admin."
+is_owner,long,true,"1 indicating the user is an owner."
+is_primary_owner,long,true,"1 indicating the user is a primary owner."
+is_slack_message,long,true,"1 indicating the item is a message."
+message_file_size,long,"Total size of files in a message if present."
+metadata__enriched_on,date,true,"Date when the item was enriched."
+metadata__gelk_backend_name,keyword,true,"Name of the backend used to enrich information."
+metadata__gelk_version,keyword,true,"Version of the backend used to enrich information."
+metadata__timestamp,date,true,"Date when the item was stored in RAW index."
+metadata__updated_on,date,true,"Date when the item was updated on its original data source."
+number_attachs,long,true,"Number of attachments in a message."
+number_files,long,true,"Number of files a message contains if present."
+origin,keyword,true,"Original URL where the channel was retrieved from."
+profile_title,keyword,true,"Title in a user profile."
+project,keyword,true,"Project."
+project_1,keyword,true,"Project (if more than one level is allowed in project hierarchy)."
+reaction_count,long,true,"Number of reactions on a message."
+reactions,keyword,true,"Reactions on a message."
+reply_count,long,true,"Number of replies on a message."
+repository_labels,keyword,true,"Custom repository labels defined by the user."
+subscribed,long,true,"1 indicating message type is subscribed."
+subtype,keyword,true,"Message subtype."
+tag,keyword,true,"Perceval tag."
+team_id,keyword,true,"Team Id."
+text,keyword,true,"Message text."
+text_analyzed,keyword,true,"Message body in plain text."
+type,keyword,true,"Slack item type."
+tz,long,true,"Timezone of the user."
+unread_count,long,true,"Number of unread messages."
+user,keyword,true,"Slack user."
+user_data_bot,long,true,"1 if the given user is identified as a bot."
+user_data_domain,keyword,true,"Domain associated to the user in SortingHat profile."
+user_data_gender,keyword,true,"User gender, based on her name (disabled by default)."
+user_data_gender_acc,long,true,"User gender accuracy (disabled by default)."
+user_data_id,keyword,true,"User Id from SortingHat."
+user_data_multi_org_names,keyword,true,"List of the user organizations from SortingHat profile."
+user_data_name,keyword,true,"User's name from SortingHat profile"
+user_data_org_name,keyword,true,"User's organization name from SortingHat profile."
+user_data_user_name,keyword,true,"User's username from SortingHat profile."
+user_data_uuid,keyword,true,"User's UUID from SortingHat profile."
+uuid,keyword,true,"Perceval UUID."

--- a/tests/data/slack.json
+++ b/tests/data/slack.json
@@ -911,4 +911,208 @@
     "timestamp": 1518165795.539766,
     "updated_on": 1427135634.000066,
     "uuid": "e59d9ca0d9a2ba1c747dc60a0904edd22d69e20e"
-}]
+},
+{
+    "backend_name": "Slack",
+    "backend_version": "0.9.0",
+    "category": "message",
+    "classified_fields_filtered": null,
+    "data": {
+        "blocks": [
+            {
+                "block_id": "qg2",
+                "elements": [
+                    {
+                        "elements": [
+                            {
+                                "text": "This message contains 2 files",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    }
+                ],
+                "type": "rich_text"
+            }
+        ],
+         "channel_info": {
+            "created": 1480595743,
+            "creator": "U0001",
+            "id": "C011DUKE8",
+            "is_archived": false,
+            "is_channel": true,
+            "is_general": true,
+            "is_member": true,
+            "is_read_only": false,
+            "last_read": "1489127926.000217",
+            "latest": {
+                "bot_id": "B0001",
+                "subtype": "bot_message",
+                "text": "There are no events this week.",
+                "ts": "1486969200.000136",
+                "type": "message"
+            },
+            "members": [
+                "U0001",
+                "U0002",
+                "U0003"
+            ],
+            "name": "test channel",
+            "name_normalized": "test channel",
+            "num_members": 4565,
+            "previous_names": [],
+            "purpose": {
+                "creator": "",
+                "last_set": 0,
+                "value": "Test channel."
+            },
+            "topic": {
+                "creator": "",
+                "last_set": 0,
+                "value": "A test channel for testing Perceval"
+            },
+            "unread_count": 1,
+            "unread_count_display": 1
+        },
+        "client_msg_id": "1234id",
+        "files": [
+            {
+                "created": 1588324635,
+                "display_as_bot": false,
+                "edit_link": "https://testteam-gvn2512.slack.com/files/1234ABC/5678ABC/helloworld.py/edit",
+                "editable": true,
+                "external_type": "",
+                "filetype": "python",
+                "has_rich_preview": false,
+                "id": "F0138UG83GR",
+                "is_external": false,
+                "is_public": true,
+                "is_starred": false,
+                "lines": 2,
+                "lines_more": 0,
+                "mimetype": "text/plain",
+                "mode": "snippet",
+                "name": "helloworld.py",
+                "permalink": "https://testteam-gvn2512.slack.com/files/1234ABC/5678ABC/helloworld.py",
+                "permalink_public": "https://slack-files.com/123MNO-FGH123-PQR234",
+                "pretty_type": "Python",
+                "preview": "print(\"Hello world\")\n",
+                "preview_highlight": "<div class=\"CodeMirror cm-s-default CodeMirrorServer\" oncopy=\"if(event.clipboardData){event.clipboardData.setData('text/plain',window.getSelection().toString().replace(/\\u200b/g,''));event.preventDefault();event.stopPropagation();}\">\n<div class=\"CodeMirror-code\">\n<div><pre><span class=\"cm-builtin\">print</span>(<span class=\"cm-string\">&quot;Hello world&quot;</span>)</pre></div>\n</div>\n</div>\n",
+                "preview_is_truncated": false,
+                "public_url_shared": false,
+                "size": 2123,
+                "timestamp": 1588324635,
+                "title": "helloworld.py",
+                "url_private": "https://files.slack.com/files-pri/123MNO-FGH123/helloworld.py",
+                "url_private_download": "https://files.slack.com/files-pri/123MNO-FGH123/download/helloworld.py",
+                "user": "U0003",
+                "username": ""
+            },
+            {
+                "created": 1588324635,
+                "display_as_bot": false,
+                "edit_link": "https://testteam-gvn2512.slack.com/files/987XYZ/IJK345/test_file/edit",
+                "editable": true,
+                "external_type": "",
+                "filetype": "text",
+                "has_rich_preview": false,
+                "id": "F0138UG8481",
+                "is_external": false,
+                "is_public": true,
+                "is_starred": false,
+                "lines": 2,
+                "lines_more": 0,
+                "mimetype": "text/plain",
+                "mode": "snippet",
+                "name": "test file",
+                "permalink": "https://testteam-gvn2512.slack.com/files/987XYZ/IJK345/test_file",
+                "permalink_public": "https://slack-files.com/JKL456-MNO123-ABC345",
+                "pretty_type": "Plain text",
+                "preview": "Data inside test file\n",
+                "preview_highlight": "<div class=\"CodeMirror cm-s-default CodeMirrorServer\" oncopy=\"if(event.clipboardData){event.clipboardData.setData('text/plain',window.getSelection().toString().replace(/\\u200b/g,''));event.preventDefault();event.stopPropagation();}\">\n<div class=\"CodeMirror-code\">\n<div><pre>Data inside test file</pre></div>\n<div><pre></pre></div>\n</div>\n</div>\n",
+                "preview_is_truncated": false,
+                "public_url_shared": false,
+                "size": 2465,
+                "timestamp": 1588324635,
+                "title": "test file",
+                "url_private": "https://files.slack.com/files-pri/JKL456-MNO123/test_file",
+                "url_private_download": "https://files.slack.com/files-pri/JKL456-MNO123/download/test_file",
+                "user": "U0003",
+                "username": ""
+            }
+        ],
+        "reactions": [
+            {
+                "count": 1,
+                "name": "+1",
+                "users": [
+                    "U0001"
+                ]
+            },
+            {
+                "count": 1,
+                "name": "slightly_smiling_face",
+                "users": [
+                    "U0003"
+                ]
+            }
+        ],
+        "text": "This message contains 2 files",
+        "ts": "1588324642.000100",
+        "type": "message",
+        "upload": true,
+        "user": "U0002",
+        "user_data": {
+            "color": "e7392d",
+            "deleted": false,
+            "id": "U0002",
+            "is_admin": false,
+            "is_app_user": false,
+            "is_bot": false,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "name": "animesh_username",
+            "profile": {
+                "avatar_hash": "1234hash",
+                "display_name": "Animesh",
+                "display_name_normalized": "Animesh",
+                "image_192": "https://secure.gravatar.com",
+                "image_24": "https://secure.gravatar.com",
+                "image_32": "https://secure.gravatar.com",
+                "image_48": "https://secure.gravatar.com",
+                "image_512": "https://secure.gravatar.com",
+                "image_72": "https://secure.gravatar.com",
+                "phone": "",
+                "real_name": "Animesh",
+                "real_name_normalized": "Animesh",
+                "skype": "",
+                "status_emoji": "",
+                "status_expiration": 0,
+                "status_text": "",
+                "status_text_canonical": "",
+                "team": "T0001",
+                "title": ""
+            },
+            "real_name": "Animesh",
+            "team_id": "T0001",
+            "tz": "Asia/Kolkata",
+            "tz_label": "India Standard Time",
+            "tz_offset": 19800,
+            "updated": 1588082878
+        }
+    },
+    "origin": "https://slack.com/C011DUKE8",
+    "perceval_version": "0.13.0",
+    "search_fields": {
+        "channel_id": "C011DUKE8",
+        "channel_name": "test channel",
+        "item_id": "1588324642.0U08900H12100NA1V"
+    },
+    "tag": "https://slack.com/C011DUKE8",
+    "timestamp": 1588324850.898842,
+    "updated_on": 1588324642.0001,
+    "uuid": "8bc7cbaa1fe5a6a56d5758a05100e838bf6f47c2"
+}
+]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -44,8 +44,8 @@ class TestSlack(TestBaseBackend):
         """Test whether JSON items are properly inserted into ES"""
 
         result = self._test_items_to_raw()
-        self.assertEqual(result['items'], 9)
-        self.assertEqual(result['raw'], 9)
+        self.assertEqual(result['items'], 10)
+        self.assertEqual(result['raw'], 10)
 
         for item in self.items:
             self.ocean_backend._fix_item(item)
@@ -56,8 +56,8 @@ class TestSlack(TestBaseBackend):
         """Test whether the raw index is properly enriched"""
 
         result = self._test_raw_to_enrich()
-        self.assertEqual(result['raw'], 9)
-        self.assertEqual(result['enrich'], 9)
+        self.assertEqual(result['raw'], 10)
+        self.assertEqual(result['enrich'], 10)
 
         enrich_backend = self.connectors[self.connector][2]()
 
@@ -69,6 +69,12 @@ class TestSlack(TestBaseBackend):
         for item in self.items[1:]:
             eitem = enrich_backend.get_rich_item(item)
             self.assertEqual(eitem['channel_member_count'], 4565)
+
+        # test to check if files in a message is enriched
+        item = self.items[9]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['number_files'], 2)
+        self.assertEqual(eitem['message_file_size'], 4588)
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
@@ -84,8 +90,8 @@ class TestSlack(TestBaseBackend):
         """Test enrich with SortingHat"""
 
         result = self._test_raw_to_enrich(sortinghat=True)
-        self.assertEqual(result['raw'], 9)
-        self.assertEqual(result['enrich'], 9)
+        self.assertEqual(result['raw'], 10)
+        self.assertEqual(result['enrich'], 10)
 
         enrich_backend = self.connectors[self.connector][2]()
         enrich_backend.sortinghat = True
@@ -116,8 +122,8 @@ class TestSlack(TestBaseBackend):
         """Test enrich with Projects"""
 
         result = self._test_raw_to_enrich(projects=True)
-        self.assertEqual(result['raw'], 9)
-        self.assertEqual(result['enrich'], 9)
+        self.assertEqual(result['raw'], 10)
+        self.assertEqual(result['enrich'], 10)
 
         res = requests.get(self.es_con + "/" + self.enrich_index + "/_search", verify=False)
         for eitem in res.json()['hits']['hits']:


### PR DESCRIPTION
This commit removes enriching single files,
since a message can contain multiple files.
Instead, two new metric, number of files and
file size per message have been included.

The schema has been updated.
The tests have been updated accordingly.

Signed-off-by: Animesh Kumar <animuz111@gmail.com>